### PR TITLE
Fix start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Dashboard for visualizing SEC 8-K Item 1.05 security breach disclosures",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "fetch-data": "node sec-data-fetcher.js",
-    "update-dashboard": "node update-dashboard.js"
+    "start": "node server.js",
+    "fetch-data": "node sec-data-fetcher.js"
   },
   "dependencies": {
     "axios": "^1.8.3",


### PR DESCRIPTION
## Summary
- run `server.js` from `npm start`
- remove unused `update-dashboard` script

## Testing
- `npm run fetch-data` *(fails: querySrv ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6849e4953b008332843fdad5fd111815